### PR TITLE
chore - change the host name

### DIFF
--- a/kubeflow/common/istio/ingress-certificate.yaml
+++ b/kubeflow/common/istio/ingress-certificate.yaml
@@ -8,6 +8,6 @@ spec:
   issuerRef:
     name: kubeflow-self-signing-issuer
     kind: ClusterIssuer
-  commonName: kubeflow.example.com
+  commonName: kubeflow.cluster.external
   dnsNames:
-    - kubeflow.example.com
+    - kubeflow.cluster.external


### PR DESCRIPTION
Not something big but a bit more meaningful for the self-signed cert's name. 
It's better for the others to know where the trusted certs come from.